### PR TITLE
Update PyDriller integration

### DIFF
--- a/graphrepo/drillers/cache_driller.py
+++ b/graphrepo/drillers/cache_driller.py
@@ -16,7 +16,7 @@
 and indexes it in neo4j
 """
 from datetime import datetime
-from pydriller import RepositoryMining
+from pydriller.repository_mining import RepositoryMining
 
 import graphrepo.utils as utl
 import graphrepo.drillers.batch_utils as b_utl

--- a/graphrepo/drillers/default.py
+++ b/graphrepo/drillers/default.py
@@ -17,7 +17,7 @@
 from abc import abstractmethod
 from datetime import datetime
 from py2neo import Graph
-from pydriller import RepositoryMining
+from pydriller.repository_mining import RepositoryMining
 
 import graphrepo.utils as utl
 import graphrepo.drillers.batch_utils as b_utl

--- a/graphrepo/drillers/driller.py
+++ b/graphrepo/drillers/driller.py
@@ -18,7 +18,7 @@ and indexes it in neo4j
 from diskcache import Cache
 from datetime import datetime
 from py2neo import Graph
-from pydriller import RepositoryMining
+from pydriller.repository_mining import RepositoryMining
 
 import graphrepo.utils as utl
 import graphrepo.drillers.batch_utils as b_utl

--- a/graphrepo/drillers/queue_driller.py
+++ b/graphrepo/drillers/queue_driller.py
@@ -16,7 +16,7 @@
 from abc import abstractmethod
 from datetime import datetime
 from py2neo import Graph
-from pydriller import RepositoryMining
+from pydriller.repository_mining import RepositoryMining
 
 import graphrepo.utils as utl
 from graphrepo.config import Config

--- a/graphrepo/drillers/rabbit_driller.py
+++ b/graphrepo/drillers/rabbit_driller.py
@@ -19,7 +19,7 @@ import pika
 from abc import abstractmethod
 from datetime import datetime
 from py2neo import Graph
-from pydriller import RepositoryMining
+from pydriller.repository_mining import RepositoryMining
 
 import graphrepo.utils as utl
 from graphrepo.config import Config

--- a/graphrepo/drillers/stomp_driller.py
+++ b/graphrepo/drillers/stomp_driller.py
@@ -19,7 +19,7 @@ import json
 from abc import abstractmethod
 from datetime import datetime
 from py2neo import Graph
-from pydriller import RepositoryMining
+from pydriller.repository_mining import RepositoryMining
 
 import graphrepo.utils as utl
 from graphrepo.config import Config

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ lizard
 pytz
 psutil
 py2neo
-pydriller
+pydriller>=2.7.0
 requests
 pytest
 GitPython


### PR DESCRIPTION
## Summary
- depend on a recent PyDriller release
- update imports to new `pydriller.repository_mining` path

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'diskcache')*
- `python -m examples.index_all --config=examples/configs/pydriller.yml` *(fails: ModuleNotFoundError: No module named 'diskcache')*


------
https://chatgpt.com/codex/tasks/task_e_6885576da454832993b86933be13bb8d