### PR TITLE
Update PyDriller import path

### DIFF
--- a/graphrepo/drillers/cache_driller.py
+++ b/graphrepo/drillers/cache_driller.py
@@ -16,7 +16,10 @@
 and indexes it in neo4j
 """
 from datetime import datetime
-from pydriller import RepositoryMining
+try:  # PyDriller 2.x
+    from pydriller.repository_mining import RepositoryMining
+except ImportError:
+    from pydriller import RepositoryMining
 
 import graphrepo.utils as utl
 import graphrepo.drillers.batch_utils as b_utl

--- a/graphrepo/drillers/cache_driller.py
+++ b/graphrepo/drillers/cache_driller.py
@@ -16,10 +16,14 @@
 and indexes it in neo4j
 """
 from datetime import datetime
-try:  # PyDriller 2.x
-    from pydriller.repository_mining import RepositoryMining
-except ImportError:
+# PyDriller recently reorganized modules, try all known import locations
+try:
     from pydriller import RepositoryMining
+except ImportError:
+    try:
+        from pydriller.repository_mining import RepositoryMining
+    except ImportError:
+        from pydriller.git_mining import RepositoryMining
 
 import graphrepo.utils as utl
 import graphrepo.drillers.batch_utils as b_utl

--- a/graphrepo/drillers/default.py
+++ b/graphrepo/drillers/default.py
@@ -17,7 +17,10 @@
 from abc import abstractmethod
 from datetime import datetime
 from py2neo import Graph
-from pydriller import RepositoryMining
+try:  # PyDriller 2.x
+    from pydriller.repository_mining import RepositoryMining
+except ImportError:
+    from pydriller import RepositoryMining
 
 import graphrepo.utils as utl
 import graphrepo.drillers.batch_utils as b_utl

--- a/graphrepo/drillers/default.py
+++ b/graphrepo/drillers/default.py
@@ -17,10 +17,14 @@
 from abc import abstractmethod
 from datetime import datetime
 from py2neo import Graph
-try:  # PyDriller 2.x
-    from pydriller.repository_mining import RepositoryMining
-except ImportError:
+# PyDriller recently reorganized modules, try all known import locations
+try:
     from pydriller import RepositoryMining
+except ImportError:
+    try:
+        from pydriller.repository_mining import RepositoryMining
+    except ImportError:
+        from pydriller.git_mining import RepositoryMining
 
 import graphrepo.utils as utl
 import graphrepo.drillers.batch_utils as b_utl

--- a/graphrepo/drillers/driller.py
+++ b/graphrepo/drillers/driller.py
@@ -19,13 +19,7 @@ from diskcache import Cache
 from datetime import datetime
 from py2neo import Graph
 # PyDriller recently reorganized modules, try all known import locations
-try:
-    from pydriller import RepositoryMining
-except ImportError:
-    try:  # PyDriller 2.x
-        from pydriller.repository_mining import RepositoryMining
-    except ImportError:  # PyDriller 3.x
-        from pydriller.git_mining import RepositoryMining
+from pydriller import RepositoryMining
 
 import graphrepo.utils as utl
 import graphrepo.drillers.batch_utils as b_utl

--- a/graphrepo/drillers/driller.py
+++ b/graphrepo/drillers/driller.py
@@ -18,7 +18,10 @@ and indexes it in neo4j
 from diskcache import Cache
 from datetime import datetime
 from py2neo import Graph
-from pydriller import RepositoryMining
+try:  # PyDriller 2.x
+    from pydriller.repository_mining import RepositoryMining
+except ImportError:  # Fallback for older versions
+    from pydriller import RepositoryMining
 
 import graphrepo.utils as utl
 import graphrepo.drillers.batch_utils as b_utl

--- a/graphrepo/drillers/driller.py
+++ b/graphrepo/drillers/driller.py
@@ -18,10 +18,14 @@ and indexes it in neo4j
 from diskcache import Cache
 from datetime import datetime
 from py2neo import Graph
-try:  # PyDriller 2.x
-    from pydriller.repository_mining import RepositoryMining
-except ImportError:  # Fallback for older versions
+# PyDriller recently reorganized modules, try all known import locations
+try:
     from pydriller import RepositoryMining
+except ImportError:
+    try:  # PyDriller 2.x
+        from pydriller.repository_mining import RepositoryMining
+    except ImportError:  # PyDriller 3.x
+        from pydriller.git_mining import RepositoryMining
 
 import graphrepo.utils as utl
 import graphrepo.drillers.batch_utils as b_utl

--- a/graphrepo/drillers/queue_driller.py
+++ b/graphrepo/drillers/queue_driller.py
@@ -16,7 +16,10 @@
 from abc import abstractmethod
 from datetime import datetime
 from py2neo import Graph
-from pydriller import RepositoryMining
+try:
+    from pydriller.repository_mining import RepositoryMining
+except ImportError:
+    from pydriller import RepositoryMining
 
 import graphrepo.utils as utl
 from graphrepo.config import Config

--- a/graphrepo/drillers/queue_driller.py
+++ b/graphrepo/drillers/queue_driller.py
@@ -16,10 +16,14 @@
 from abc import abstractmethod
 from datetime import datetime
 from py2neo import Graph
+# PyDriller recently reorganized modules, try all known import locations
 try:
-    from pydriller.repository_mining import RepositoryMining
-except ImportError:
     from pydriller import RepositoryMining
+except ImportError:
+    try:
+        from pydriller.repository_mining import RepositoryMining
+    except ImportError:
+        from pydriller.git_mining import RepositoryMining
 
 import graphrepo.utils as utl
 from graphrepo.config import Config

--- a/graphrepo/drillers/rabbit_driller.py
+++ b/graphrepo/drillers/rabbit_driller.py
@@ -19,7 +19,10 @@ import pika
 from abc import abstractmethod
 from datetime import datetime
 from py2neo import Graph
-from pydriller import RepositoryMining
+try:
+    from pydriller.repository_mining import RepositoryMining
+except ImportError:
+    from pydriller import RepositoryMining
 
 import graphrepo.utils as utl
 from graphrepo.config import Config

--- a/graphrepo/drillers/rabbit_driller.py
+++ b/graphrepo/drillers/rabbit_driller.py
@@ -19,10 +19,14 @@ import pika
 from abc import abstractmethod
 from datetime import datetime
 from py2neo import Graph
+# PyDriller recently reorganized modules, try all known import locations
 try:
-    from pydriller.repository_mining import RepositoryMining
-except ImportError:
     from pydriller import RepositoryMining
+except ImportError:
+    try:
+        from pydriller.repository_mining import RepositoryMining
+    except ImportError:
+        from pydriller.git_mining import RepositoryMining
 
 import graphrepo.utils as utl
 from graphrepo.config import Config

--- a/graphrepo/drillers/stomp_driller.py
+++ b/graphrepo/drillers/stomp_driller.py
@@ -19,10 +19,14 @@ import json
 from abc import abstractmethod
 from datetime import datetime
 from py2neo import Graph
+# PyDriller recently reorganized modules, try all known import locations
 try:
-    from pydriller.repository_mining import RepositoryMining
-except ImportError:
     from pydriller import RepositoryMining
+except ImportError:
+    try:
+        from pydriller.repository_mining import RepositoryMining
+    except ImportError:
+        from pydriller.git_mining import RepositoryMining
 
 import graphrepo.utils as utl
 from graphrepo.config import Config

--- a/graphrepo/drillers/stomp_driller.py
+++ b/graphrepo/drillers/stomp_driller.py
@@ -19,7 +19,10 @@ import json
 from abc import abstractmethod
 from datetime import datetime
 from py2neo import Graph
-from pydriller import RepositoryMining
+try:
+    from pydriller.repository_mining import RepositoryMining
+except ImportError:
+    from pydriller import RepositoryMining
 
 import graphrepo.utils as utl
 from graphrepo.config import Config

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ lizard
 pytz
 psutil
 py2neo
-pydriller>=2.5
+pydriller==1.9.6
 requests
 pytest
 GitPython

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ lizard
 pytz
 psutil
 py2neo
-pydriller
+pydriller>=2.5
 requests
 pytest
 GitPython


### PR DESCRIPTION
## Summary
- guard PyDriller import to work across versions
- pin pydriller 2.5+ in requirements

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'diskcache')*
- `python -m examples.index_all --config=examples/configs/pydriller.yml` *(fails: ModuleNotFoundError: No module named 'diskcache')*


------
https://chatgpt.com/codex/tasks/task_e_6885576da454832993b86933be13bb8d